### PR TITLE
Fix for Dango sticking to walls

### DIFF
--- a/DangoPlop/Assets/Physics/Bounce.physicsMaterial2D
+++ b/DangoPlop/Assets/Physics/Bounce.physicsMaterial2D
@@ -7,4 +7,4 @@ PhysicsMaterial2D:
   m_PrefabInternal: {fileID: 0}
   m_Name: Bounce
   friction: 0
-  bounciness: 1
+  bounciness: 0

--- a/DangoPlop/Assets/_Scenes/Gameplay.unity
+++ b/DangoPlop/Assets/_Scenes/Gameplay.unity
@@ -325,7 +325,7 @@ Rigidbody2D:
   m_GameObject: {fileID: 577200287}
   m_BodyType: 0
   m_Simulated: 1
-  m_UseFullKinematicContacts: 0
+  m_UseFullKinematicContacts: 1
   m_UseAutoMass: 0
   m_Mass: 1
   m_LinearDrag: 0
@@ -427,7 +427,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 577200287}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 52d6d5e52c35e8f4f807a49fa510f7dc, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0


### PR DESCRIPTION
Reference https://trello.com/c/ZMVvwwZe

Default physics material has friction. Since player movement is
translated as velocity, Dango sticks to the walls.

Solution is to use another physics material called Bounce and change its
friction value to 0 and set the bounce value to 0 too.