### PR TITLE
Add 2nd chance powerup

### DIFF
--- a/DangoPlop/Assets/PowerupLife.cs
+++ b/DangoPlop/Assets/PowerupLife.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PowerupLife : PowerupParent {
+	public override void HandlePowerupAction(float powerupLastingTime){
+		powerupMaster.startPowerupAction (PowerupType.Life, powerupLastingTime);
+	}
+}

--- a/DangoPlop/Assets/PowerupLife.cs.meta
+++ b/DangoPlop/Assets/PowerupLife.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9bcd3c0ab7f047a4298e8cec887dcd00
+timeCreated: 1503813810
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DangoPlop/Assets/Prefabs/PowerupLife.prefab
+++ b/DangoPlop/Assets/Prefabs/PowerupLife.prefab
@@ -1,0 +1,154 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1802535036316162}
+  m_IsPrefabParent: 1
+--- !u!1 &1802535036316162
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4610056479460550}
+  - component: {fileID: 212105990891334660}
+  - component: {fileID: 50786439421601310}
+  - component: {fileID: 58317753076265540}
+  - component: {fileID: 58561102755585402}
+  - component: {fileID: 114833051257591648}
+  m_Layer: 0
+  m_Name: PowerupLife
+  m_TagString: Powerup
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4610056479460550
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802535036316162}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &50786439421601310
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802535036316162}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!58 &58317753076265540
+CircleCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802535036316162}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.95
+--- !u!58 &58561102755585402
+CircleCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802535036316162}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 1
+--- !u!114 &114833051257591648
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802535036316162}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bcd3c0ab7f047a4298e8cec887dcd00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeLandedToDestroy: 3
+  verticalSpeed: 2
+  powerupExplosion: {fileID: 1373985343339942, guid: f989474e11aa74082b243f06fdef7afc,
+    type: 2}
+  powerupGlow: {fileID: 1374429659103120, guid: 5635a64fa82454042addfa93354b19b0,
+    type: 2}
+  timeLastingPowerup: 0
+--- !u!212 &212105990891334660
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802535036316162}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1542925157
+  m_SortingLayer: 1
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 2b460af89b712de47b5a56c99135fe6a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0

--- a/DangoPlop/Assets/Prefabs/PowerupLife.prefab.meta
+++ b/DangoPlop/Assets/Prefabs/PowerupLife.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 392fc9ee68dac1e4bb3a3690c6bb6eae
+timeCreated: 1503813687
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DangoPlop/Assets/Scripts/PlayerController.cs
+++ b/DangoPlop/Assets/Scripts/PlayerController.cs
@@ -40,6 +40,7 @@ public class PlayerController : MonoBehaviour {
 	public bool AmmoReset = false;
 	public bool Froze;
 	public bool has2ndLife = false;
+	private GameObject shield;
 
 	private PowerupMaster powerupMaster;
 
@@ -51,6 +52,8 @@ public class PlayerController : MonoBehaviour {
 		originalScale = gameObject.transform.lossyScale;
 		originalHeight = gameObject.transform.position.y;
 		powerupMaster = GameObject.FindGameObjectWithTag ("PowerupPanel").GetComponent<PowerupMaster> ();
+		shield = GameObject.FindGameObjectWithTag("Shield");
+		deactivateShield();
     }
 	void FixedUpdate() {
 
@@ -112,6 +115,7 @@ public class PlayerController : MonoBehaviour {
 			if(!has2ndLife)
 				FindObjectOfType<GameOverMenu>().EndGame();
 			else
+				deactivateShield();
 				has2ndLife = false;
         }
     }
@@ -169,6 +173,16 @@ public class PlayerController : MonoBehaviour {
 		bulletType = BulletType.DefaultFire;
 		AmmoReset = true;
 
+	}
+
+	public void activateShield()
+	{
+		shield.SetActive( true );
+	}
+
+	public void deactivateShield()
+	{
+		shield.SetActive( false );
 	}
 	
     IEnumerator Wait()

--- a/DangoPlop/Assets/Scripts/PlayerController.cs
+++ b/DangoPlop/Assets/Scripts/PlayerController.cs
@@ -39,6 +39,7 @@ public class PlayerController : MonoBehaviour {
 	public BulletType bulletType = BulletType.DefaultFire;
 	public bool AmmoReset = false;
 	public bool Froze;
+	public bool has2ndLife = false;
 
 	private PowerupMaster powerupMaster;
 
@@ -108,7 +109,10 @@ public class PlayerController : MonoBehaviour {
     {
         if (collision.gameObject.tag == "Ball")
         {
-           FindObjectOfType<GameOverMenu>().EndGame();
+			if(!has2ndLife)
+				FindObjectOfType<GameOverMenu>().EndGame();
+			else
+				has2ndLife = false;
         }
     }
 

--- a/DangoPlop/Assets/Scripts/PowerupMaster.cs
+++ b/DangoPlop/Assets/Scripts/PowerupMaster.cs
@@ -228,6 +228,7 @@ public class PowerupMaster : MonoBehaviour {
 	private void give2ndLife()
 	{
 		playerController.has2ndLife = true;
+		playerController.activateShield();
 	}
 
 	// MAKE YOUR POWERUP FUNCTIONS HERE

--- a/DangoPlop/Assets/Scripts/PowerupMaster.cs
+++ b/DangoPlop/Assets/Scripts/PowerupMaster.cs
@@ -109,6 +109,7 @@ public class PowerupMaster : MonoBehaviour {
 			break;
 		case PowerupType.Life:
 			renderComponent.sprite = powerupLife;
+			give2ndLife();
 			break;
 		case PowerupType.Random:
 			renderComponent.sprite = powerupRandom;
@@ -222,6 +223,11 @@ public class PowerupMaster : MonoBehaviour {
 
 	private void setRapidFire(){
 		playerController.rapidFire ();
+	}
+
+	private void give2ndLife()
+	{
+		playerController.has2ndLife = true;
 	}
 
 	// MAKE YOUR POWERUP FUNCTIONS HERE

--- a/DangoPlop/Assets/_Scenes/Gameplay.unity
+++ b/DangoPlop/Assets/_Scenes/Gameplay.unity
@@ -361,6 +361,75 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &163181814
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 163181815}
+  - component: {fileID: 163181818}
+  - component: {fileID: 163181816}
+  m_Layer: 0
+  m_Name: Shield
+  m_TagString: Shield
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &163181815
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 163181814}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 7, y: 7, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1112566743}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &163181816
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 163181814}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 98e870b8c048443bf94fbdfcbe59650b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &163181818
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 163181814}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &232083495
 GameObject:
   m_ObjectHideFlags: 0
@@ -984,6 +1053,7 @@ Transform:
   m_Children:
   - {fileID: 1440078411}
   - {fileID: 1624177324}
+  - {fileID: 163181815}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/DangoPlop/Assets/_Scenes/Gameplay.unity
+++ b/DangoPlop/Assets/_Scenes/Gameplay.unity
@@ -890,6 +890,7 @@ MonoBehaviour:
   bulletType: 0
   AmmoReset: 0
   Froze: 0
+  has2ndLife: 0
 --- !u!50 &1112566740
 Rigidbody2D:
   serializedVersion: 4
@@ -970,7 +971,6 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
 --- !u!4 &1112566743
 Transform:
   m_ObjectHideFlags: 0
@@ -1178,7 +1178,6 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
 --- !u!1 &1197787038
 GameObject:
   m_ObjectHideFlags: 0
@@ -1774,7 +1773,6 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
 --- !u!61 &1823898791
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -1920,7 +1918,6 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
 --- !u!114 &1960204568
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2084,7 +2081,6 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
 --- !u!1 &2048020147
 GameObject:
   m_ObjectHideFlags: 0

--- a/DangoPlop/ProjectSettings/TagManager.asset
+++ b/DangoPlop/ProjectSettings/TagManager.asset
@@ -11,6 +11,7 @@ TagManager:
   - Ceiling
   - PowerupPanel
   - Ground
+  - Shield
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Backend of powerup is player object tracking state of 2nd life powerup.

Frontend adding a 3d Quad to Dango with its Material set as
part_shockwave_mat.

Powerup master can enable shield if life powerup has collided with
Dango. Dango worry about deactivating shield if it's hit by ball.